### PR TITLE
(bug) Caching does not works in monorepo setup

### DIFF
--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -54,4 +54,3 @@ runs:
         cache-to: type=gha,mode=max,scope=${{ github.head_ref }}-${{ inputs.app_name }}
         outputs: type=image,push=true
         secrets: ${{ inputs.build_secrets }}
-

--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -3,7 +3,7 @@ description: 'Build application from Dockerfile'
 inputs:
   app_name:
     required: true
-    description: "Application name based on which docker repository, doppler project and kube namespace would be selected"
+    description: "Application name based on which build is cached"
   docker_registry:
     required: true
     description: 'Docker registry where build images would be pushed and pulled from'

--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -1,6 +1,9 @@
 name: 'build'
 description: 'Build application from Dockerfile'
 inputs:
+  app_name:
+    required: true
+    description: "Application name based on which docker repository, doppler project and kube namespace would be selected"
   docker_registry:
     required: true
     description: 'Docker registry where build images would be pushed and pulled from'
@@ -42,14 +45,13 @@ runs:
 
     - name: Docker build
       id: build
-      uses: docker/build-push-action@v2
+      uses: docker/build-push-action@v4
       with:
         context: ${{ inputs.context }}
         tags: ${{ inputs.tags }}
         build-args: ${{ inputs.build_args }}
-        # @see - https://docs.docker.com/build/ci/github-actions/cache/#github-cache
-        cache-from: type=gha
-        cache-to: type=gha,mode=max
+        cache-from: type=gha,scope=${{ github.head_ref }}-${{ inputs.app_name }}
+        cache-to: type=gha,mode=max,scope=${{ github.head_ref }}-${{ inputs.app_name }}
         outputs: type=image,push=true
-        # @see - https://docs.docker.com/build/ci/github-actions/secrets/
         secrets: ${{ inputs.build_secrets }}
+

--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -50,7 +50,9 @@ runs:
         context: ${{ inputs.context }}
         tags: ${{ inputs.tags }}
         build-args: ${{ inputs.build_args }}
+        # @see - https://docs.docker.com/build/ci/github-actions/cache/#github-cache
         cache-from: type=gha,scope=${{ github.head_ref }}-${{ inputs.app_name }}
         cache-to: type=gha,mode=max,scope=${{ github.head_ref }}-${{ inputs.app_name }}
         outputs: type=image,push=true
+        # @see - https://docs.docker.com/build/ci/github-actions/secrets/
         secrets: ${{ inputs.build_secrets }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -174,6 +174,7 @@ jobs:
         id: build
         uses: ./platform/.github/actions/build
         with:
+          app_name: ${{ inputs.app_name }}
           tags: ${{ inputs.docker_registry }}/${{ inputs.docker_username }}/${{ inputs.app_name }}:${{ steps.extract_branch.outputs.branch_hash }}
           build_args: ${{ inputs.build_args }}
           build_secrets: ${{ secrets.build_secrets }}


### PR DESCRIPTION
- As build step uses the same key for caching which is based on commit and PR, the cache cannot work if building multiple apps under same commit / PR.

Point of failure - https://github.com/jalantechnologies/github-ci/blob/main/.github/actions/build/action.yml
App for testing - https://github.com/jalantechnologies/boilerplate-gatsby-strapi