### PR TITLE
(feat) Build on PRs should be able to use cache from base branch

### DIFF
--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -54,7 +54,7 @@ runs:
         # multiple cache sources - in case of pull requests, we'd like to reuse cache from base branch
         # @see - https://github.com/moby/moby/issues/34715#issuecomment-425933774
         cache-from: |
-          ${{ github.event.number == 0 && type=gha,scope=${{ github.base_ref }}-${{ inputs.app_name }} || '' }}
+          ${{ github.event.number == 0 && 'type=gha,scope=${{ github.base_ref }}-${{ inputs.app_name }}' || '' }}
           type=gha,scope=${{ github.head_ref || github.ref_name }}-${{ inputs.app_name }}
         cache-to: type=gha,mode=max,scope=${{ github.head_ref || github.ref_name }}-${{ inputs.app_name }}
         outputs: type=image,push=true

--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -51,8 +51,12 @@ runs:
         tags: ${{ inputs.tags }}
         build-args: ${{ inputs.build_args }}
         # @see - https://docs.docker.com/build/ci/github-actions/cache/#github-cache
-        cache-from: type=gha,scope=${{ github.head_ref }}-${{ inputs.app_name }}
-        cache-to: type=gha,mode=max,scope=${{ github.head_ref }}-${{ inputs.app_name }}
+        # multiple cache sources - in case of pull requests, we'd like to reuse cache from base branch
+        # @see - https://github.com/moby/moby/issues/34715#issuecomment-425933774
+        cache-from:
+          - type=gha,scope=${{ github.base_ref }}-${{ inputs.app_name }}
+          - type=gha,scope=${{ github.ref_name }}-${{ inputs.app_name }}
+        cache-to: type=gha,mode=max,scope=${{ github.ref_name }}-${{ inputs.app_name }}
         outputs: type=image,push=true
         # @see - https://docs.docker.com/build/ci/github-actions/secrets/
         secrets: ${{ inputs.build_secrets }}

--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -54,7 +54,7 @@ runs:
         # multiple cache sources - in case of pull requests (github.base_ref), we'd like to reuse cache from base branch
         # @see - https://github.com/moby/moby/issues/34715#issuecomment-425933774
         cache-from: |
-          ${{ github.base_ref != '' && format('type=gha,scope={0}-{1}', github.base_ref, inputs.app_name) }}
+          ${{ github.base_ref == '' && format('type=gha,scope={0}-{1}', github.base_ref, inputs.app_name) }}
           type=gha,scope=${{ github.head_ref || github.ref_name }}-${{ inputs.app_name }}
         cache-to: type=gha,mode=max,scope=${{ github.head_ref || github.ref_name }}-${{ inputs.app_name }}
         outputs: type=image,push=true

--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -54,7 +54,7 @@ runs:
         # multiple cache sources - in case of pull requests (github.base_ref), we'd like to reuse cache from base branch
         # @see - https://github.com/moby/moby/issues/34715#issuecomment-425933774
         cache-from: |
-          ${{ github.base_ref != '' && 'type=gha,scope=${{ github.base_ref }}-${{ inputs.app_name }}' || '' }}
+          ${{ github.base_ref != '' && format('type=gha,scope={0}-{1}', github.base_ref, inputs.app_name) }}
           type=gha,scope=${{ github.head_ref || github.ref_name }}-${{ inputs.app_name }}
         cache-to: type=gha,mode=max,scope=${{ github.head_ref || github.ref_name }}-${{ inputs.app_name }}
         outputs: type=image,push=true

--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -55,8 +55,8 @@ runs:
         # @see - https://github.com/moby/moby/issues/34715#issuecomment-425933774
         cache-from: |
           type=gha,scope=${{ github.base_ref }}-${{ inputs.app_name }}
-          type=gha,scope=${{ github.ref_name }}-${{ inputs.app_name }}
-        cache-to: type=gha,mode=max,scope=${{ github.ref_name }}-${{ inputs.app_name }}
+          type=gha,scope=${{ github.head_ref || github.ref_name }}-${{ inputs.app_name }}
+        cache-to: type=gha,mode=max,scope=${{ github.head_ref || github.ref_name }}-${{ inputs.app_name }}
         outputs: type=image,push=true
         # @see - https://docs.docker.com/build/ci/github-actions/secrets/
         secrets: ${{ inputs.build_secrets }}

--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -53,9 +53,9 @@ runs:
         # @see - https://docs.docker.com/build/ci/github-actions/cache/#github-cache
         # multiple cache sources - in case of pull requests, we'd like to reuse cache from base branch
         # @see - https://github.com/moby/moby/issues/34715#issuecomment-425933774
-        cache-from:
-          - type=gha,scope=${{ github.base_ref }}-${{ inputs.app_name }}
-          - type=gha,scope=${{ github.ref_name }}-${{ inputs.app_name }}
+        cache-from: |
+          type=gha,scope=${{ github.base_ref }}-${{ inputs.app_name }}
+          type=gha,scope=${{ github.ref_name }}-${{ inputs.app_name }}
         cache-to: type=gha,mode=max,scope=${{ github.ref_name }}-${{ inputs.app_name }}
         outputs: type=image,push=true
         # @see - https://docs.docker.com/build/ci/github-actions/secrets/

--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -54,7 +54,7 @@ runs:
         # multiple cache sources - in case of pull requests (github.base_ref), we'd like to reuse cache from base branch
         # @see - https://github.com/moby/moby/issues/34715#issuecomment-425933774
         cache-from: |
-          ${{ github.base_ref == '' && format('type=gha,scope={0}-{1}', github.base_ref, inputs.app_name) }}
+          ${{ github.base_ref != '' && format('type=gha,scope={0}-{1}', github.base_ref, inputs.app_name) || '' }}
           type=gha,scope=${{ github.head_ref || github.ref_name }}-${{ inputs.app_name }}
         cache-to: type=gha,mode=max,scope=${{ github.head_ref || github.ref_name }}-${{ inputs.app_name }}
         outputs: type=image,push=true

--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -51,10 +51,10 @@ runs:
         tags: ${{ inputs.tags }}
         build-args: ${{ inputs.build_args }}
         # @see - https://docs.docker.com/build/ci/github-actions/cache/#github-cache
-        # multiple cache sources - in case of pull requests, we'd like to reuse cache from base branch
+        # multiple cache sources - in case of pull requests (github.base_ref), we'd like to reuse cache from base branch
         # @see - https://github.com/moby/moby/issues/34715#issuecomment-425933774
         cache-from: |
-          ${{ github.event.number == 0 && 'type=gha,scope=${{ github.base_ref }}-${{ inputs.app_name }}' || '' }}
+          ${{ github.base_ref != '' && 'type=gha,scope=${{ github.base_ref }}-${{ inputs.app_name }}' || '' }}
           type=gha,scope=${{ github.head_ref || github.ref_name }}-${{ inputs.app_name }}
         cache-to: type=gha,mode=max,scope=${{ github.head_ref || github.ref_name }}-${{ inputs.app_name }}
         outputs: type=image,push=true

--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -54,7 +54,7 @@ runs:
         # multiple cache sources - in case of pull requests, we'd like to reuse cache from base branch
         # @see - https://github.com/moby/moby/issues/34715#issuecomment-425933774
         cache-from: |
-          type=gha,scope=${{ github.base_ref }}-${{ inputs.app_name }}
+          ${{ github.event.number == 0 && type=gha,scope=${{ github.base_ref }}-${{ inputs.app_name }} || '' }}
           type=gha,scope=${{ github.head_ref || github.ref_name }}-${{ inputs.app_name }}
         cache-to: type=gha,mode=max,scope=${{ github.head_ref || github.ref_name }}-${{ inputs.app_name }}
         outputs: type=image,push=true


### PR DESCRIPTION
## Description

- This adds support for using cache from base branch (ex - `main`) when building branch from pull request