### PR TITLE
fix: Fix issue with docker_username getting marked as sensitive

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,6 +70,10 @@ on:
         type: string
         description: 'Docker registry where built images will be pushed. By default uses Docker Hub.'
         default: registry.hub.docker.com
+      docker_username:
+        required: false
+        type: string
+        description: 'Username for authenticating with provided Docker registry'
       do_cluster_id:
         required: false
         type: string
@@ -93,9 +97,6 @@ on:
       build_secrets:
         required: false
         description: 'Build secrets provided to the docker daemon when building docker image'
-      docker_username:
-        required: false
-        description: 'Username for authenticating with provided Docker registry'
       docker_password:
         required: false
         description: 'Password for authenticating with provided Docker registry'
@@ -209,7 +210,7 @@ jobs:
           build_secrets: ${{ secrets.build_secrets }}
           context: app/${{ inputs.build_context }}
           docker_registry: ${{ inputs.docker_registry }}
-          docker_username: ${{ secrets.docker_username }}
+          docker_username: ${{ inputs.docker_username }}
           docker_password: ${{ secrets.docker_password }}
 
   checks:
@@ -245,7 +246,7 @@ jobs:
           aws_region: ${{ inputs.aws_region }}
           aws_use_ecr: ${{ inputs.aws_use_ecr }}
           docker_registry: ${{ inputs.docker_registry }}
-          docker_username: ${{ secrets.docker_username }}
+          docker_username: ${{ inputs.docker_username }}
           docker_password: ${{ secrets.docker_password }}
 
   deploy:
@@ -282,7 +283,7 @@ jobs:
           deploy_labels: gh/workflow-version=${{ needs.build.outputs.workflow_ci_version }} gh/workflow-run=${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
           deploy_image: ${{ needs.build.outputs.image_ref }}
           docker_registry: ${{ inputs.docker_registry }}
-          docker_username: ${{ secrets.docker_username }}
+          docker_username: ${{ inputs.docker_username }}
           docker_password: ${{ secrets.docker_password }}
           do_access_token: ${{ secrets.do_access_token }}
           do_cluster_id: ${{ inputs.do_cluster_id }}

--- a/.github/workflows/clean.yml
+++ b/.github/workflows/clean.yml
@@ -34,6 +34,10 @@ on:
         type: string
         description: 'Docker registry where built images will be pushed. By default uses Docker Hub.'
         default: registry.hub.docker.com
+      docker_username:
+        required: false
+        type: string
+        description: 'Username for authenticating with provided Docker registry'
       do_cluster_id:
         required: false
         type: string
@@ -46,9 +50,6 @@ on:
       aws_secret_access_key:
         required: false
         description: 'Access key Secret for AWS'
-      docker_username:
-        required: false
-        description: 'Username for authenticating with provided Docker registry'
       docker_password:
         required: false
         description: 'Password for authenticating with provided Docker registry'
@@ -137,7 +138,7 @@ jobs:
       - name: Authenticate - DockerHub
         id: auth_docker_hub
         env:
-          DOCKER_USERNAME: ${{ secrets.docker_username }}
+          DOCKER_USERNAME: ${{ inputs.docker_username }}
           DOCKER_PASSWORD: ${{ secrets.docker_password }}
         if: env.DOCKER_USERNAME != '' && inputs.docker_registry == 'registry.hub.docker.com'
         shell: bash
@@ -157,5 +158,5 @@ jobs:
         if: env.DOCKER_TOKEN != ''
         shell: bash
         run: |
-          curl --location --request DELETE "https://hub.docker.com/v2/repositories/${{ secrets.docker_username }}/${{ inputs.app_name }}/tags/${{ steps.extract_branch.outputs.branch_hash }}/" \
+          curl --location --request DELETE "https://hub.docker.com/v2/repositories/${{ inputs.docker_username }}/${{ inputs.app_name }}/tags/${{ steps.extract_branch.outputs.branch_hash }}/" \
           --header "Authorization: Bearer $DOCKER_TOKEN"


### PR DESCRIPTION
## Description

This moves docker_username back to inputs as using this as secret was causing this values being marked as sensitive. This was then causing issues with subsequent jobs (deploy, checks) not able to obtain the image.