### PR TITLE
`Bug` NPM checks getting ignored for npm:lint:ts or npm:lint:py

### DIFF
--- a/.github/actions/check/action.yml
+++ b/.github/actions/check/action.yml
@@ -109,7 +109,8 @@ runs:
       shell: bash
       run: |
         echo "QQQQQQQQQ: ${{ steps.check.outputs.scheme }}"
-        echo "WWWWWWW: ${{ steps }}"
+        echo "WWWWWWW: ${{ steps.check }}"
+        echo "EEEEEEE: ${{ steps.check.outputs }}"
         echo "Running npm check with input: ${{ steps.check.outputs.input }}"
         docker run -t ${{ inputs.image }} npm run ${{ steps.check.outputs.input }}
 

--- a/.github/actions/check/action.yml
+++ b/.github/actions/check/action.yml
@@ -45,6 +45,7 @@ runs:
         echo "::set-output name=input::${CHECK#*:}"
 
     - name: Debug Docker setup
+      shell: bash
       run: |
         echo "Setting up Docker..."
 
@@ -52,6 +53,7 @@ runs:
       uses: docker/setup-buildx-action@v2
 
     - name: Debug Docker login
+      shell: bash
       run: |
         echo "DOCKER_USERNAME: ${{ inputs.docker_username }}"
         echo "DOCKER_REGISTRY: ${{ inputs.docker_registry }}"
@@ -67,6 +69,7 @@ runs:
         password: ${{ inputs.docker_password }}
 
     - name: Debug AWS setup
+      shell: bash
       run: |
         echo "AWS_USE_ECR: ${{ inputs.aws_use_ecr }}"
         echo "AWS_ACCESS_KEY_ID: ${{ inputs.aws_access_key_id }}"

--- a/.github/actions/check/action.yml
+++ b/.github/actions/check/action.yml
@@ -40,23 +40,11 @@ runs:
       env:
         CHECK: ${{ inputs.check }}
       run: |
-        echo "Processing check: $CHECK"
-        echo "::set-output name=scheme::${CHECK%:*}"
+        echo "::set-output name=scheme::${CHECK%%:*}"
         echo "::set-output name=input::${CHECK#*:}"
-
-    - name: Debug Docker setup
-      shell: bash
-      run: |
-        echo "Setting up Docker..."
 
     - name: Docker setup
       uses: docker/setup-buildx-action@v2
-
-    - name: Debug Docker login
-      shell: bash
-      run: |
-        echo "DOCKER_USERNAME: ${{ inputs.docker_username }}"
-        echo "DOCKER_REGISTRY: ${{ inputs.docker_registry }}"
 
     - name: Docker login
       uses: docker/login-action@v2
@@ -67,13 +55,6 @@ runs:
         registry: ${{ inputs.docker_registry }}
         username: ${{ inputs.docker_username }}
         password: ${{ inputs.docker_password }}
-
-    - name: Debug AWS setup
-      shell: bash
-      run: |
-        echo "AWS_USE_ECR: ${{ inputs.aws_use_ecr }}"
-        echo "AWS_ACCESS_KEY_ID: ${{ inputs.aws_access_key_id }}"
-        echo "AWS_REGION: ${{ inputs.aws_region }}"
 
     - name: AWS setup
       uses: aws-actions/configure-aws-credentials@v1
@@ -96,23 +77,12 @@ runs:
     - name: Docker pull
       shell: bash
       run: |
-        echo "Pulling image: ${{ inputs.image }}"
         docker pull ${{ inputs.image }}
         docker tag ${{ inputs.image }} ${{ inputs.tag }}
 
     # runs check using npm
     # for a check - npm:lint
     # will execute - npm run lint
-
-    - name: Debug Run check using npm
-      # if: steps.check.outputs.scheme == 'npm'
-      shell: bash
-      run: |
-        echo "QQQQQQQQQ: ${{ steps.check.outputs.scheme }}"
-        echo "WWWWWWW: ${{ steps.check }}"
-        echo "EEEEEEE: ${{ steps.check.outputs }}"
-        echo "Running npm check with input: ${{ steps.check.outputs.input }}"
-        docker run -t ${{ inputs.image }} npm run ${{ steps.check.outputs.input }}
 
     - name: Run check using npm
       if: steps.check.outputs.scheme == 'npm'
@@ -125,13 +95,6 @@ runs:
     # will look for compose file - docker-compose.test.yml and will run the services.
     # service named 'app' should run and exit successfully to mark the test successful
     # to reference the app's image, inputs.tag can be used
-
-    - name: Debug Run check using compose
-      if: steps.check.outputs.scheme == 'compose'
-      shell: bash
-      run: |
-        echo "Running docker-compose check with input: ${{ steps.check.outputs.input }}"
-        docker-compose -f app/docker-compose.${{ steps.check.outputs.input }}.yml up --exit-code-from app
 
     - name: Run check using compose
       if: steps.check.outputs.scheme == 'compose'

--- a/.github/actions/check/action.yml
+++ b/.github/actions/check/action.yml
@@ -108,7 +108,8 @@ runs:
       # if: steps.check.outputs.scheme == 'npm'
       shell: bash
       run: |
-        echo steps.check.outputs.scheme
+        echo "QQQQQQQQQ: ${{ steps.check.outputs.scheme }}"
+        echo "WWWWWWW: ${{ steps }}"
         echo "Running npm check with input: ${{ steps.check.outputs.input }}"
         docker run -t ${{ inputs.image }} npm run ${{ steps.check.outputs.input }}
 

--- a/.github/actions/check/action.yml
+++ b/.github/actions/check/action.yml
@@ -105,9 +105,10 @@ runs:
     # will execute - npm run lint
 
     - name: Debug Run check using npm
-      if: steps.check.outputs.scheme == 'npm'
+      # if: steps.check.outputs.scheme == 'npm'
       shell: bash
       run: |
+        echo steps.check.outputs.scheme
         echo "Running npm check with input: ${{ steps.check.outputs.input }}"
         docker run -t ${{ inputs.image }} npm run ${{ steps.check.outputs.input }}
 

--- a/.github/actions/check/action.yml
+++ b/.github/actions/check/action.yml
@@ -40,11 +40,21 @@ runs:
       env:
         CHECK: ${{ inputs.check }}
       run: |
+        echo "Processing check: $CHECK"
         echo "::set-output name=scheme::${CHECK%:*}"
         echo "::set-output name=input::${CHECK#*:}"
 
+    - name: Debug Docker setup
+      run: |
+        echo "Setting up Docker..."
+
     - name: Docker setup
       uses: docker/setup-buildx-action@v2
+
+    - name: Debug Docker login
+      run: |
+        echo "DOCKER_USERNAME: ${{ inputs.docker_username }}"
+        echo "DOCKER_REGISTRY: ${{ inputs.docker_registry }}"
 
     - name: Docker login
       uses: docker/login-action@v2
@@ -55,6 +65,12 @@ runs:
         registry: ${{ inputs.docker_registry }}
         username: ${{ inputs.docker_username }}
         password: ${{ inputs.docker_password }}
+
+    - name: Debug AWS setup
+      run: |
+        echo "AWS_USE_ECR: ${{ inputs.aws_use_ecr }}"
+        echo "AWS_ACCESS_KEY_ID: ${{ inputs.aws_access_key_id }}"
+        echo "AWS_REGION: ${{ inputs.aws_region }}"
 
     - name: AWS setup
       uses: aws-actions/configure-aws-credentials@v1
@@ -77,12 +93,20 @@ runs:
     - name: Docker pull
       shell: bash
       run: |
+        echo "Pulling image: ${{ inputs.image }}"
         docker pull ${{ inputs.image }}
         docker tag ${{ inputs.image }} ${{ inputs.tag }}
 
     # runs check using npm
     # for a check - npm:lint
     # will execute - npm run lint
+
+    - name: Debug Run check using npm
+      if: steps.check.outputs.scheme == 'npm'
+      shell: bash
+      run: |
+        echo "Running npm check with input: ${{ steps.check.outputs.input }}"
+        docker run -t ${{ inputs.image }} npm run ${{ steps.check.outputs.input }}
 
     - name: Run check using npm
       if: steps.check.outputs.scheme == 'npm'
@@ -95,6 +119,13 @@ runs:
     # will look for compose file - docker-compose.test.yml and will run the services.
     # service named 'app' should run and exit successfully to mark the test successful
     # to reference the app's image, inputs.tag can be used
+
+    - name: Debug Run check using compose
+      if: steps.check.outputs.scheme == 'compose'
+      shell: bash
+      run: |
+        echo "Running docker-compose check with input: ${{ steps.check.outputs.input }}"
+        docker-compose -f app/docker-compose.${{ steps.check.outputs.input }}.yml up --exit-code-from app
 
     - name: Run check using compose
       if: steps.check.outputs.scheme == 'compose'


### PR DESCRIPTION
## Description

As we want steps.check.outputs.scheme to be 'npm' or anything before first colon
We should use ${CHECK%%:} instead of ${CHECK%:}. The difference is that ${CHECK%%:} removes everything after the first colon (:), while ${CHECK%:} removes everything after the last colon (:).