### PR TITLE
(bug) "docker-compose: command not found" when running compose:* checks

### DIFF
--- a/.github/actions/check/action.yml
+++ b/.github/actions/check/action.yml
@@ -100,7 +100,7 @@ runs:
       if: steps.check.outputs.scheme == 'compose'
       shell: bash
       run: |
-        docker-compose -f app/docker-compose.${{ steps.check.outputs.input }}.yml up --exit-code-from app
+        docker compose -f app/docker-compose.${{ steps.check.outputs.input }}.yml up --exit-code-from app
 
     - name: Coverage Report
       continue-on-error: true


### PR DESCRIPTION
## Description

This fixes issue with workflows running on new GH runners where docker-compose command is removed and replaced with a newer version - `docker compose`

See discussion: https://github.com/orgs/community/discussions/116610#discussioncomment-8997411