### PR TITLE
Fix: deployment failing due to lower priority

### DIFF
--- a/.github/actions/deploy/action.yml
+++ b/.github/actions/deploy/action.yml
@@ -26,9 +26,6 @@ inputs:
   branch:
     required: true
     description: 'Branch from which this action was run'
-  commit_sha:
-    required: false
-    description: 'Commit SHA for the deployment'
   deploy_root:
     required: true
     description: 'Directory where kube deployment would look for kubernetes specification files'
@@ -115,7 +112,6 @@ runs:
       # kube configurations can use following environment variables along with the default ones provided by GitHub action
       # https://docs.github.com/en/actions/learn-github-actions/environment-variables#default-environment-variables
       env:
-        COMMIT_SHA: ${{ inputs.commit_sha }}
         DOCKER_REGISTRY: ${{ inputs.docker_registry }}
         DOCKER_USERNAME: ${{ inputs.docker_username }}
         DOCKER_PASSWORD: ${{ inputs.docker_password }}

--- a/.github/actions/deploy/action.yml
+++ b/.github/actions/deploy/action.yml
@@ -26,6 +26,9 @@ inputs:
   branch:
     required: true
     description: 'Branch from which this action was run'
+  commit_sha:
+    required: false
+    description: 'Commit SHA for the deployment'
   deploy_root:
     required: true
     description: 'Directory where kube deployment would look for kubernetes specification files'
@@ -112,6 +115,7 @@ runs:
       # kube configurations can use following environment variables along with the default ones provided by GitHub action
       # https://docs.github.com/en/actions/learn-github-actions/environment-variables#default-environment-variables
       env:
+        COMMIT_SHA: ${{ inputs.commit_sha }}
         DOCKER_REGISTRY: ${{ inputs.docker_registry }}
         DOCKER_USERNAME: ${{ inputs.docker_username }}
         DOCKER_PASSWORD: ${{ inputs.docker_password }}

--- a/.github/actions/deploy/action.yml
+++ b/.github/actions/deploy/action.yml
@@ -53,6 +53,9 @@ inputs:
   doppler_token:
     required: false
     description: 'Doppler token for accessing environment variables'
+  workflow_run_number:
+    required: false
+    description: 'Workflow run number'
 outputs:
   url:
     description: 'URL where application has been deployed'
@@ -125,6 +128,7 @@ runs:
         KUBE_DEPLOYMENT_IMAGE: ${{ inputs.deploy_image }}
         KUBE_INGRESS_HOSTNAME: ${{ format(inputs.app_hostname, inputs.app_env, steps.extract_branch.outputs.branch_hash) }}
         KUBE_LABELS: gh/actor=${{ steps.extract_branch.outputs.branch_actor }} gh/commit=${{ steps.extract_branch.outputs.branch_commit_hash }} ${{ inputs.deploy_labels }}
+        KUBE_DEPLOY_ID: ${{ inputs.workflow_run_number }}
       run: |
         source platform/lib/kube/deploy.sh
         echo "##[set-output name=url;]$(echo https://$KUBE_INGRESS_HOSTNAME)"

--- a/.github/actions/deploy/action.yml
+++ b/.github/actions/deploy/action.yml
@@ -26,6 +26,9 @@ inputs:
   branch:
     required: true
     description: 'Branch from which this action was run'
+  deploy_id:
+    required: false
+    description: 'Unique identifier which can also be used for giving priority to resources created during deployment process'
   deploy_root:
     required: true
     description: 'Directory where kube deployment would look for kubernetes specification files'
@@ -53,9 +56,6 @@ inputs:
   doppler_token:
     required: false
     description: 'Doppler token for accessing environment variables'
-  workflow_run_number:
-    required: false
-    description: 'Workflow run number'
 outputs:
   url:
     description: 'URL where application has been deployed'
@@ -128,7 +128,7 @@ runs:
         KUBE_DEPLOYMENT_IMAGE: ${{ inputs.deploy_image }}
         KUBE_INGRESS_HOSTNAME: ${{ format(inputs.app_hostname, inputs.app_env, steps.extract_branch.outputs.branch_hash) }}
         KUBE_LABELS: gh/actor=${{ steps.extract_branch.outputs.branch_actor }} gh/commit=${{ steps.extract_branch.outputs.branch_commit_hash }} ${{ inputs.deploy_labels }}
-        KUBE_DEPLOY_ID: ${{ inputs.workflow_run_number }}
+        KUBE_DEPLOY_ID: ${{ inputs.deploy_id }}
       run: |
         source platform/lib/kube/deploy.sh
         echo "##[set-output name=url;]$(echo https://$KUBE_INGRESS_HOSTNAME)"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,10 +55,6 @@ on:
         required: false
         type: string
         description: 'Checks to be performed. Provide here list of checks in scheme:input format where scheme can be - npm, compose.'
-      commit_sha:
-        required: false
-        type: string
-        description: 'Commit SHA for which this workflow was run'
       deploy_root:
         required: false
         type: string
@@ -283,7 +279,6 @@ jobs:
           aws_secret_access_key: ${{ secrets.aws_secret_access_key }}
           aws_region: ${{ inputs.aws_region }}
           branch: ${{ inputs.branch }}
-          commit_sha: ${{ inputs.commit_sha}}
           deploy_root: app/${{ inputs.deploy_root }}
           deploy_labels: gh/workflow-version=${{ needs.build.outputs.workflow_ci_version }} gh/workflow-run=${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
           deploy_image: ${{ needs.build.outputs.image_ref }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,10 @@ on:
         required: false
         type: string
         description: 'Checks to be performed. Provide here list of checks in scheme:input format where scheme can be - npm, compose.'
+      commit_sha:
+        required: false
+        type: string
+        description: 'Commit SHA for which this workflow was run'
       deploy_root:
         required: false
         type: string
@@ -279,6 +283,7 @@ jobs:
           aws_secret_access_key: ${{ secrets.aws_secret_access_key }}
           aws_region: ${{ inputs.aws_region }}
           branch: ${{ inputs.branch }}
+          commit_sha: ${{ inputs.commit_sha}}
           deploy_root: app/${{ inputs.deploy_root }}
           deploy_labels: gh/workflow-version=${{ needs.build.outputs.workflow_ci_version }} gh/workflow-run=${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
           deploy_image: ${{ needs.build.outputs.image_ref }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,6 +86,10 @@ on:
         required: false
         type: string
         description: 'SonarQube server URL. If not provided, analysis will not be performed.'
+      workflow_run_number:
+        required: false
+        type: number
+        description: 'Run number of the workflow'
 
     secrets:
       aws_access_key_id:
@@ -288,6 +292,7 @@ jobs:
           do_access_token: ${{ secrets.do_access_token }}
           do_cluster_id: ${{ inputs.do_cluster_id }}
           doppler_token: ${{ secrets.doppler_token }}
+          workflow_run_number: ${{ inputs.workflow_run_number }}
 
       - uses: marocchino/sticky-pull-request-comment@v2
         # only run this step if enabled and pull request number was provided

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,10 +86,6 @@ on:
         required: false
         type: string
         description: 'SonarQube server URL. If not provided, analysis will not be performed.'
-      workflow_run_number:
-        required: false
-        type: number
-        description: 'Run number of the workflow'
 
     secrets:
       aws_access_key_id:
@@ -292,7 +288,7 @@ jobs:
           do_access_token: ${{ secrets.do_access_token }}
           do_cluster_id: ${{ inputs.do_cluster_id }}
           doppler_token: ${{ secrets.doppler_token }}
-          workflow_run_number: ${{ inputs.workflow_run_number }}
+          workflow_run_number: ${{ github.run_number }}
 
       - uses: marocchino/sticky-pull-request-comment@v2
         # only run this step if enabled and pull request number was provided

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -279,6 +279,7 @@ jobs:
           aws_secret_access_key: ${{ secrets.aws_secret_access_key }}
           aws_region: ${{ inputs.aws_region }}
           branch: ${{ inputs.branch }}
+          deploy_id: ${{ github.run_number }}
           deploy_root: app/${{ inputs.deploy_root }}
           deploy_labels: gh/workflow-version=${{ needs.build.outputs.workflow_ci_version }} gh/workflow-run=${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
           deploy_image: ${{ needs.build.outputs.image_ref }}
@@ -288,7 +289,6 @@ jobs:
           do_access_token: ${{ secrets.do_access_token }}
           do_cluster_id: ${{ inputs.do_cluster_id }}
           doppler_token: ${{ secrets.doppler_token }}
-          workflow_run_number: ${{ github.run_number }}
 
       - uses: marocchino/sticky-pull-request-comment@v2
         # only run this step if enabled and pull request number was provided

--- a/lib/kube/deploy.sh
+++ b/lib/kube/deploy.sh
@@ -10,7 +10,6 @@
 get_highest_priority_from_pods() {
     # Get priority values from running pods in the specified namespace
     priority_values=$(kubectl get pods -n "$KUBE_NS" -o custom-columns=PRIORITY:.spec.priority --no-headers 2>/dev/null)
-    echo "debug :: priority values - $priority_values"
     
     if [ -z "$priority_values" ]; then
         echo "No pods found or no priority values available"

--- a/lib/kube/deploy.sh
+++ b/lib/kube/deploy.sh
@@ -7,7 +7,6 @@
 
 # custom vars
 # Set KUBE_DEPLOY_ID using the commit SHA
-COMMIT_SHA=$(git rev-parse HEAD)
 export KUBE_DEPLOY_ID=$(echo "$COMMIT_SHA" | md5sum | tr -dc '0-9' | head -c 9)
 
 # Ensure it's within the valid range

--- a/lib/kube/deploy.sh
+++ b/lib/kube/deploy.sh
@@ -6,7 +6,7 @@
 # optional - DOPPLER_TOKEN, DOPPLER_TOKEN_SECRET_NAME, DOPPLER_MANAGED_SECRET_NAME, KUBE_LABELS
 
 # custom vars
-# function to get the highest priority class value
+# Function to get the highest priority class value
 get_highest_priority_from_pods() {
     # Get priority values from running pods in the specified namespace
     priority_values=$(kubectl get pods -n "$KUBE_NS" -o custom-columns=PRIORITY:.spec.priority --no-headers 2>/dev/null)
@@ -22,12 +22,15 @@ get_highest_priority_from_pods() {
 
 # Get the current highest priority value from pods
 HIGHEST_PRIORITY=$(get_highest_priority_from_pods)
+echo "debug :: highest priority - $HIGHEST_PRIORITY"
 
-# Generate a base deployment ID based on the current timestamp
-BASE_ID=$(( ($(date +%s) + 500) % 1000000 ))
+# Generate a base deployment ID based on the current timestamp, ensuring it's within the range 1 to 1000000000
+BASE_ID=$(( ( $(date +%s) % 1000000000 ) + 1 ))
+echo "debug :: base deployment ID - $BASE_ID"
 
-# Ensure the BASE_ID is within a valid range
-KUBE_DEPLOY_ID=$(( (BASE_ID % (1000000000 - 1)) + 1 ))
+# Set the deployment ID initially to the base ID
+KUBE_DEPLOY_ID=$BASE_ID
+echo "debug :: initial deployment ID - $KUBE_DEPLOY_ID"
 
 # If the KUBE_DEPLOY_ID is not greater than the highest priority class, adjust it
 if [ -n "$HIGHEST_PRIORITY" ]; then
@@ -38,6 +41,7 @@ if [ -n "$HIGHEST_PRIORITY" ]; then
         fi
     fi
 fi
+echo "debug :: adjusted deployment ID - $KUBE_DEPLOY_ID"
 
 # Export the ID
 export KUBE_DEPLOY_ID

--- a/lib/kube/deploy.sh
+++ b/lib/kube/deploy.sh
@@ -6,41 +6,6 @@
 # optional - DOPPLER_TOKEN, DOPPLER_TOKEN_SECRET_NAME, DOPPLER_MANAGED_SECRET_NAME, KUBE_LABELS
 
 # custom vars
-# Function to get the highest priority class value
-get_highest_priority_from_pods() {
-    # Get priority values from running pods in the specified namespace
-    priority_values=$(kubectl get pods -n "$KUBE_NS" -o custom-columns=PRIORITY:.spec.priority --no-headers 2>/dev/null)
-    
-    if [ -z "$priority_values" ]; then
-        echo 0
-        return
-    fi
-
-    # Extract the highest priority value
-    echo "$priority_values" | sort -n | tail -1
-}
-
-# Get the current highest priority value from pods
-HIGHEST_PRIORITY=$(get_highest_priority_from_pods)
-
-# Generate a base deployment ID based on the current timestamp, ensuring it's within the range 1 to 1000000000
-BASE_ID=$(( ( $(date +%s) % 1000000000 ) + 1 ))
-
-# Set the deployment ID initially to the base ID
-KUBE_DEPLOY_ID=$BASE_ID
-
-# If the KUBE_DEPLOY_ID is not greater than the highest priority class, adjust it
-if [ -n "$HIGHEST_PRIORITY" ]; then
-    if [ "$KUBE_DEPLOY_ID" -le "$HIGHEST_PRIORITY" ]; then
-        KUBE_DEPLOY_ID=$((HIGHEST_PRIORITY + 1))
-        if [ "$KUBE_DEPLOY_ID" -gt 1000000000 ]; then
-            KUBE_DEPLOY_ID=1000000000
-        fi
-    fi
-fi
-
-# Export the ID
-export KUBE_DEPLOY_ID
 
 echo "deploy :: starting deployment procedure"
 echo "deploy :: kube root - $KUBE_ROOT"

--- a/lib/kube/deploy.sh
+++ b/lib/kube/deploy.sh
@@ -22,15 +22,12 @@ get_highest_priority_from_pods() {
 
 # Get the current highest priority value from pods
 HIGHEST_PRIORITY=$(get_highest_priority_from_pods)
-echo "debug :: highest priority - $HIGHEST_PRIORITY"
 
 # Generate a base deployment ID based on the current timestamp, ensuring it's within the range 1 to 1000000000
 BASE_ID=$(( ( $(date +%s) % 1000000000 ) + 1 ))
-echo "debug :: base deployment ID - $BASE_ID"
 
 # Set the deployment ID initially to the base ID
 KUBE_DEPLOY_ID=$BASE_ID
-echo "debug :: initial deployment ID - $KUBE_DEPLOY_ID"
 
 # If the KUBE_DEPLOY_ID is not greater than the highest priority class, adjust it
 if [ -n "$HIGHEST_PRIORITY" ]; then
@@ -41,7 +38,6 @@ if [ -n "$HIGHEST_PRIORITY" ]; then
         fi
     fi
 fi
-echo "debug :: adjusted deployment ID - $KUBE_DEPLOY_ID"
 
 # Export the ID
 export KUBE_DEPLOY_ID

--- a/lib/kube/deploy.sh
+++ b/lib/kube/deploy.sh
@@ -12,7 +12,6 @@ get_highest_priority_from_pods() {
     priority_values=$(kubectl get pods -n "$KUBE_NS" -o custom-columns=PRIORITY:.spec.priority --no-headers 2>/dev/null)
     
     if [ -z "$priority_values" ]; then
-        echo "No pods found or no priority values available"
         echo 0
         return
     fi
@@ -23,15 +22,12 @@ get_highest_priority_from_pods() {
 
 # Get the current highest priority value from pods
 HIGHEST_PRIORITY=$(get_highest_priority_from_pods)
-echo "debug :: highest priority - $HIGHEST_PRIORITY"
 
 # Generate a base deployment ID based on the current timestamp
 BASE_ID=$(( ($(date +%s) + 500) % 1000000 ))
-echo "debug :: base id - $BASE_ID"
 
 # Ensure the BASE_ID is within a valid range
 KUBE_DEPLOY_ID=$(( (BASE_ID % (1000000000 - 1)) + 1 ))
-echo "debug :: deploy id - $KUBE_DEPLOY_ID"
 
 # If the KUBE_DEPLOY_ID is not greater than the highest priority class, adjust it
 if [ -n "$HIGHEST_PRIORITY" ]; then
@@ -42,7 +38,6 @@ if [ -n "$HIGHEST_PRIORITY" ]; then
         fi
     fi
 fi
-echo "debug :: adjusted deploy id - $KUBE_DEPLOY_ID"
 
 # Export the ID
 export KUBE_DEPLOY_ID

--- a/lib/kube/deploy.sh
+++ b/lib/kube/deploy.sh
@@ -6,8 +6,14 @@
 # optional - DOPPLER_TOKEN, DOPPLER_TOKEN_SECRET_NAME, DOPPLER_MANAGED_SECRET_NAME, KUBE_LABELS
 
 # custom vars
-# deployment id based on current timestamp
-export KUBE_DEPLOY_ID=$(( ($(date +%s) + 500) % 1000000 ))
+# Set KUBE_DEPLOY_ID using the commit SHA
+COMMIT_SHA=$(git rev-parse HEAD)
+export KUBE_DEPLOY_ID=$(echo "$COMMIT_SHA" | md5sum | tr -dc '0-9' | head -c 9)
+
+# Ensure it's within the valid range
+if [ "$KUBE_DEPLOY_ID" -gt 1000000000 ]; then
+    export KUBE_DEPLOY_ID=1000000000
+fi
 
 echo "deploy :: starting deployment procedure"
 echo "deploy :: kube root - $KUBE_ROOT"


### PR DESCRIPTION
## Description

_This PR is introduced to fix the deployment fail due to `KUBE_DEPLOY_ID` getting resetted after some specific time.
`KUBE_DEPLOY_ID` is now the number which represents the `GITHUB_WORKFLOW_NUMBER` of the specific repo._

## Pros:
- The `KUBE_DEPLOY_ID` will always be increasing as ideally it should be without resetting after a certain time.
- It would take about 1 billion workflow run in a specific repository to reach the higher limit of `KUBE_DEPLOY_ID`.

## Cons:
- The only con in this method is when a workflow is re-run after a new worflow run then it would lead to failure of deployment.

## Manual Test case run:
- Opened up a PR using this workflow, deployed successfully
- Opened up another PR using workflow, deployed successfully
- Pushed a new commit in the first test PR to check the `KUBE_DEPLOY_ID` increasing, deployed successfully as well as `KUBE_DEPLOY_ID` greater than second PR's `KUBE_DEPLOY_ID`.
