### PR TITLE
Fix: Add Default Value for hosting_provider Input in Reusable Workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,9 +5,10 @@ on:
     inputs:
       # required
       hosting_provider:
-        required: true
+        required: false
         type: string
         description: 'The cloud provider to use for hosting. Options: AWS or DIGITAL_OCEAN'
+        default: 'DIGITAL_OCEAN'
 
       app_name:
         required: true

--- a/.github/workflows/clean.yml
+++ b/.github/workflows/clean.yml
@@ -5,9 +5,10 @@ on:
     inputs:
       # required
       hosting_provider:
-        required: true
+        required: false
         type: string
         description: 'The cloud provider to use for cleanup. Options: AWS or DIGITAL_OCEAN'
+        default: 'DIGITAL_OCEAN'
       app_name:
         required: true
         type: string


### PR DESCRIPTION
### Description:
This PR prepares a patch release (v3.2.1) for the reusable GitHub Actions workflows by adding a default value for the hosting_provider input.

### Why this change is needed:

- Prevents workflow failures in consumers referencing v3.2 but not passing hosting_provider.
- Ensures backward compatibility without requiring changes in downstream workflows.

### What’s changed:

- Added default: "DIGITAL_OCEAN" to the hosting_provider input in all relevant workflow files.

Release version: v3.2.1