### PR TITLE
Fix: Skip Temporal Deployment in Preview Environment via deploy.sh

### DIFF
--- a/lib/kube/deploy.sh
+++ b/lib/kube/deploy.sh
@@ -113,6 +113,12 @@ fi
 
 if [ -d "$kube_env_dir" ]; then
     for file in "$kube_env_dir"/*; do
+        # Skip temporal deployment ONLY in preview
+        if [[ "$KUBE_ENV" == "preview" && "$file" == *temporal-deployment.yaml ]]; then
+            echo "deploy :: skipping temporal deployment in preview env - $file"
+            continue
+        fi
+
         echo "deploy :: deploying from env config - $kube_env_dir/$file"
         envsubst <"$file" | kubectl apply -f -
 
@@ -121,6 +127,7 @@ if [ -d "$kube_env_dir" ]; then
         fi
     done
 fi
+
 
 # deployment post deploy hook
 if [ -f "$kube_post_deploy_script" ]; then


### PR DESCRIPTION
### Description
This PR modifies the shared deploy.sh script to skip applying the temporal-deployment.yaml file when deploying to the preview environment.
This avoids making any changes to the actual Kubernetes manifest file and isolates the logic within the deployment script.

### Why is this change needed?

- The temporal-server deployment in preview was failing due to schema/version mismatches in the managed Temporal PostgreSQL database.
- To prevent preview workflow disruptions for others on the team while a fix or upgrade path is being determined.
- Commenting out the manifest directly was discouraged; this approach uses conditional logic instead.
- Ensures deployments remain stable across environments, while still deploying Temporal in non-preview (e.g., production) environments.

### What does this PR do?

✅ Changes in deploy.sh:
- Adds a conditional block to skip temporal-deployment.yaml when the value of $KUBE_ENV is preview.
- Logs a clear message to indicate the skip (for transparency in CI output).
- Leaves all other environment and shared config deployments untouched.

🚫 No changes made to:
- temporal-deployment.yaml
- Any other workflow or manifest files

