### PR TITLE
Feat: Add Helm-Based Kubernetes Deployment to Reusable Deploy Action

### DIFF
--- a/.github/actions/deploy/action.yml
+++ b/.github/actions/deploy/action.yml
@@ -135,7 +135,11 @@ runs:
         KUBE_LABELS: gh/actor=${{ steps.extract_branch.outputs.branch_actor }} gh/commit=${{ steps.extract_branch.outputs.branch_commit_hash }} ${{ inputs.deploy_labels }}
         KUBE_DEPLOY_ID: ${{ inputs.deploy_id }}
       run: |
-        helm dependency build $KUBE_ROOT/leadgenai-chart && \
+        helm repo add doppler https://helm.doppler.com || true
+        helm repo update
+
+        helm dependency build $KUBE_ROOT/leadgenai-chart
+        
         helm upgrade --install $KUBE_APP $KUBE_ROOT/leadgenai-chart \
           -n $KUBE_NS --create-namespace \
           -f $KUBE_ROOT/leadgenai-chart/values-${KUBE_ENV}.yaml \

--- a/.github/actions/deploy/action.yml
+++ b/.github/actions/deploy/action.yml
@@ -126,6 +126,10 @@ runs:
       run: |
         doppler secrets download --format yaml --no-file | kubectl apply -f - -n $KUBE_NS
 
+    - name: Apply DopplerSecret manifest
+      shell: bash
+      run: kubectl apply -f lib/kube/leadgenai-chart/secrets/doppler-secret.yaml
+
     - name: Kubernetes deploy
       shell: bash
       id: deploy

--- a/.github/actions/deploy/action.yml
+++ b/.github/actions/deploy/action.yml
@@ -117,6 +117,11 @@ runs:
     - name: Setup Doppler CLI
       uses: dopplerhq/cli-action@v2
 
+    - name: Show working directory and files
+      run: |
+        pwd
+        ls -l lib/kube/leadgenai-chart/secrets/
+
     - name: Apply DopplerSecret manifest
       shell: bash
       run: kubectl apply -f lib/kube/leadgenai-chart/secrets/doppler-secret.yaml

--- a/.github/actions/deploy/action.yml
+++ b/.github/actions/deploy/action.yml
@@ -121,7 +121,7 @@ runs:
       shell: bash
       env:
         DOPPLER_TOKEN: ${{ inputs.doppler_token }}
-        KUBE_NS: ${{ env.KUBE_NS }}
+        KUBE_NS: ${{ inputs.app_name }}-${{ inputs.app_env }}
       if: "${{ env.DOPPLER_TOKEN != '' }}"
       run: |
         doppler secrets download --format yaml --no-file | kubectl apply -f - -n $KUBE_NS

--- a/.github/actions/deploy/action.yml
+++ b/.github/actions/deploy/action.yml
@@ -114,6 +114,13 @@ runs:
       with:
         version: v3.12.0
 
+    - name: Install/Upgrade Doppler Operator
+      run: |
+        helm repo add doppler https://helm.doppler.com || true
+        helm repo update
+        helm upgrade --install doppler-operator doppler/doppler-kubernetes-operator \
+          -n doppler-operator-system --create-namespace
+
     - name: Kubernetes deploy
       shell: bash
       id: deploy
@@ -135,9 +142,6 @@ runs:
         KUBE_LABELS: gh/actor=${{ steps.extract_branch.outputs.branch_actor }} gh/commit=${{ steps.extract_branch.outputs.branch_commit_hash }} ${{ inputs.deploy_labels }}
         KUBE_DEPLOY_ID: ${{ inputs.deploy_id }}
       run: |
-        helm repo add doppler https://helm.doppler.com || true
-        helm repo update
-
         helm dependency build $KUBE_ROOT/leadgenai-chart
         
         helm upgrade --install $KUBE_APP $KUBE_ROOT/leadgenai-chart \
@@ -149,6 +153,7 @@ runs:
           --set deployId=$KUBE_DEPLOY_ID \
           --set namespace=$KUBE_NS \
           --set gitSha=$GITHUB_SHA \
-          --set doppler.token=${{ inputs.doppler_token }}
+          --set doppler.token=${{ inputs.doppler_token }} \
+          --set doppler.installOperator=false
 
         echo "##[set-output name=url;]$(echo https://$KUBE_INGRESS_HOSTNAME)"

--- a/.github/actions/deploy/action.yml
+++ b/.github/actions/deploy/action.yml
@@ -143,6 +143,7 @@ runs:
           --set ingressHost=$KUBE_INGRESS_HOSTNAME \
           --set deployId=$KUBE_DEPLOY_ID \
           --set namespace=$KUBE_NS \
-          --set gitSha=$GITHUB_SHA
+          --set gitSha=$GITHUB_SHA \
+           **--set doppler.token=$DOPPLER_TOKEN**
 
         echo "##[set-output name=url;]$(echo https://$KUBE_INGRESS_HOSTNAME)"

--- a/.github/actions/deploy/action.yml
+++ b/.github/actions/deploy/action.yml
@@ -114,13 +114,18 @@ runs:
       with:
         version: v3.12.0
 
-    - name: Install/Upgrade Doppler Operator
+    - name: Install Doppler Operator if not exists
       shell: bash
       run: |
-        helm repo add doppler https://helm.doppler.com || true
-        helm repo update
-        helm upgrade --install doppler-operator doppler/doppler-kubernetes-operator \
-          -n doppler-operator-system --create-namespace
+        if ! helm status doppler-operator -n doppler-operator-system &>/dev/null; then
+          echo "Doppler Operator not found. Installing..."
+          helm repo add doppler https://helm.doppler.com || true
+          helm repo update
+          helm upgrade --install doppler-operator doppler/doppler-kubernetes-operator \
+            -n doppler-operator-system --create-namespace
+        else
+          echo "Doppler Operator already installed. Skipping installation."
+        fi
 
     - name: Kubernetes deploy
       shell: bash

--- a/.github/actions/deploy/action.yml
+++ b/.github/actions/deploy/action.yml
@@ -144,6 +144,6 @@ runs:
           --set deployId=$KUBE_DEPLOY_ID \
           --set namespace=$KUBE_NS \
           --set gitSha=$GITHUB_SHA \
-           **--set doppler.token=$DOPPLER_TOKEN**
+          **--set doppler.token=$DOPPLER_TOKEN**
 
         echo "##[set-output name=url;]$(echo https://$KUBE_INGRESS_HOSTNAME)"

--- a/.github/actions/deploy/action.yml
+++ b/.github/actions/deploy/action.yml
@@ -144,6 +144,6 @@ runs:
           --set deployId=$KUBE_DEPLOY_ID \
           --set namespace=$KUBE_NS \
           --set gitSha=$GITHUB_SHA \
-          **--set doppler.token=$DOPPLER_TOKEN**
+          --set doppler.token=${{ inputs.doppler_token }}
 
         echo "##[set-output name=url;]$(echo https://$KUBE_INGRESS_HOSTNAME)"

--- a/.github/actions/deploy/action.yml
+++ b/.github/actions/deploy/action.yml
@@ -109,17 +109,20 @@ runs:
       if: "${{ env.AWS_CLUSTER_NAME != '' }}"
       run: aws eks update-kubeconfig --name $AWS_CLUSTER_NAME --region $AWS_REGION
 
+    # Installing Helm (previously using shell script deploy.sh)
     - name: Install Helm
       uses: azure/setup-helm@v3
       with:
         version: v3.12.0
 
+    # Adding Doppler Helm repo
     - name: Add Doppler Helm Repo
       shell: bash
       run: |
         helm repo add doppler https://helm.doppler.com || true
         helm repo update
 
+    # Installing Doppler Operator via Helm (instead of static YAMLs)
     - name: Install Doppler Operator if not exists
       shell: bash
       run: |
@@ -131,6 +134,7 @@ runs:
           echo "Doppler Operator already installed. Skipping installation."
         fi
 
+    # Kubernetes deploy now uses Helm chart instead of deploy.sh script
     - name: Kubernetes deploy
       shell: bash
       id: deploy
@@ -153,7 +157,7 @@ runs:
         KUBE_DEPLOY_ID: ${{ inputs.deploy_id }}
       run: |
         helm dependency build $KUBE_ROOT/leadgenai-chart
-        
+
         helm upgrade --install $KUBE_APP $KUBE_ROOT/leadgenai-chart \
           -n $KUBE_NS --create-namespace \
           -f $KUBE_ROOT/leadgenai-chart/values-${KUBE_ENV}.yaml \

--- a/.github/actions/deploy/action.yml
+++ b/.github/actions/deploy/action.yml
@@ -116,14 +116,13 @@ runs:
 
     - name: Setup Doppler CLI
       uses: dopplerhq/cli-action@v2
-      with:
-        doppler-token: ${{ inputs.doppler_token }}
 
     - name: Sync Doppler secrets to Kubernetes
       shell: bash
       env:
         DOPPLER_TOKEN: ${{ inputs.doppler_token }}
-      if: "${{ env.DOPPLER_TOKEN != '' }}"
+        KUBE_NS: ${{ env.KUBE_NS }}
+      if: "${{ env.DOPPLER_TOKEN != '' }}"  
       run: |
         doppler secrets download --format kubernetes --no-file | kubectl apply -f - -n $KUBE_NS
 

--- a/.github/actions/deploy/action.yml
+++ b/.github/actions/deploy/action.yml
@@ -114,15 +114,19 @@ runs:
       with:
         version: v3.12.0
 
+    - name: Add Doppler Helm Repo
+      shell: bash
+      run: |
+        helm repo add doppler https://helm.doppler.com || true
+        helm repo update
+
     - name: Install Doppler Operator if not exists
       shell: bash
       run: |
         if ! helm status doppler-operator -n doppler-operator-system &>/dev/null; then
           echo "Doppler Operator not found. Installing..."
-          helm repo add doppler https://helm.doppler.com || true
-          helm repo update
           helm upgrade --install doppler-operator doppler/doppler-kubernetes-operator \
-            -n doppler-operator-system --create-namespace
+          -n doppler-operator-system --create-namespace
         else
           echo "Doppler Operator already installed. Skipping installation."
         fi

--- a/.github/actions/deploy/action.yml
+++ b/.github/actions/deploy/action.yml
@@ -117,15 +117,6 @@ runs:
     - name: Setup Doppler CLI
       uses: dopplerhq/cli-action@v2
 
-    - name: Sync Doppler secrets to Kubernetes
-      shell: bash
-      env:
-        DOPPLER_TOKEN: ${{ inputs.doppler_token }}
-        KUBE_NS: ${{ inputs.app_name }}-${{ inputs.app_env }}
-      if: "${{ env.DOPPLER_TOKEN != '' }}"
-      run: |
-        doppler secrets download --format yaml --no-file | kubectl apply -f - -n $KUBE_NS
-
     - name: Apply DopplerSecret manifest
       shell: bash
       run: kubectl apply -f lib/kube/leadgenai-chart/secrets/doppler-secret.yaml

--- a/.github/actions/deploy/action.yml
+++ b/.github/actions/deploy/action.yml
@@ -135,6 +135,7 @@ runs:
         KUBE_LABELS: gh/actor=${{ steps.extract_branch.outputs.branch_actor }} gh/commit=${{ steps.extract_branch.outputs.branch_commit_hash }} ${{ inputs.deploy_labels }}
         KUBE_DEPLOY_ID: ${{ inputs.deploy_id }}
       run: |
+        helm dependency build $KUBE_ROOT/leadgenai-chart && \
         helm upgrade --install $KUBE_APP $KUBE_ROOT/leadgenai-chart \
           -n $KUBE_NS --create-namespace \
           -f $KUBE_ROOT/leadgenai-chart/values-${KUBE_ENV}.yaml \

--- a/.github/actions/deploy/action.yml
+++ b/.github/actions/deploy/action.yml
@@ -115,6 +115,7 @@ runs:
         version: v3.12.0
 
     - name: Install/Upgrade Doppler Operator
+      shell: bash
       run: |
         helm repo add doppler https://helm.doppler.com || true
         helm repo update

--- a/.github/actions/deploy/action.yml
+++ b/.github/actions/deploy/action.yml
@@ -142,6 +142,7 @@ runs:
           --set image.repository=$(echo $KUBE_DEPLOYMENT_IMAGE | cut -d: -f1) \
           --set ingressHost=$KUBE_INGRESS_HOSTNAME \
           --set deployId=$KUBE_DEPLOY_ID \
+          --set namespace=$KUBE_NS \
           --set gitSha=$GITHUB_SHA
 
         echo "##[set-output name=url;]$(echo https://$KUBE_INGRESS_HOSTNAME)"

--- a/.github/actions/deploy/action.yml
+++ b/.github/actions/deploy/action.yml
@@ -114,13 +114,6 @@ runs:
       with:
         version: v3.12.0
 
-    - name: Setup Doppler CLI
-      uses: dopplerhq/cli-action@v2
-
-    - name: Apply DopplerSecret manifest
-      shell: bash
-      run: kubectl apply -f lib/kube/leadgenai-chart/secrets/doppler-secret.yaml
-
     - name: Kubernetes deploy
       shell: bash
       id: deploy

--- a/.github/actions/deploy/action.yml
+++ b/.github/actions/deploy/action.yml
@@ -109,6 +109,11 @@ runs:
       if: "${{ env.AWS_CLUSTER_NAME != '' }}"
       run: aws eks update-kubeconfig --name $AWS_CLUSTER_NAME --region $AWS_REGION
 
+    - name: Install Helm
+      uses: azure/setup-helm@v3
+      with:
+        version: v3.12.0
+
     - name: Kubernetes deploy
       shell: bash
       id: deploy
@@ -130,5 +135,13 @@ runs:
         KUBE_LABELS: gh/actor=${{ steps.extract_branch.outputs.branch_actor }} gh/commit=${{ steps.extract_branch.outputs.branch_commit_hash }} ${{ inputs.deploy_labels }}
         KUBE_DEPLOY_ID: ${{ inputs.deploy_id }}
       run: |
-        source platform/lib/kube/deploy.sh
+        helm upgrade --install $KUBE_APP $KUBE_ROOT/leadgenai-chart \
+          -n $KUBE_NS --create-namespace \
+          -f $KUBE_ROOT/leadgenai-chart/values-${KUBE_ENV}.yaml \
+          --set image.tag=$(echo $KUBE_DEPLOYMENT_IMAGE | cut -d: -f2) \
+          --set image.repository=$(echo $KUBE_DEPLOYMENT_IMAGE | cut -d: -f1) \
+          --set ingressHost=$KUBE_INGRESS_HOSTNAME \
+          --set deployId=$KUBE_DEPLOY_ID \
+          --set gitSha=$GITHUB_SHA
+          
         echo "##[set-output name=url;]$(echo https://$KUBE_INGRESS_HOSTNAME)"

--- a/.github/actions/deploy/action.yml
+++ b/.github/actions/deploy/action.yml
@@ -114,6 +114,15 @@ runs:
       with:
         version: v3.12.0
 
+    - name: Sync Doppler secrets to Kubernetes
+      shell: bash
+      env:
+        DOPPLER_TOKEN: ${{ inputs.doppler_token }}
+      if: "${{ env.DOPPLER_TOKEN != '' }}"
+      run: |
+        curl -sLf --retry 3 --retry-delay 2 https://cli.doppler.com/install.sh | sh
+        doppler secrets download --format kubernetes --no-file | kubectl apply -f - -n $KUBE_NS
+
     - name: Kubernetes deploy
       shell: bash
       id: deploy
@@ -143,5 +152,5 @@ runs:
           --set ingressHost=$KUBE_INGRESS_HOSTNAME \
           --set deployId=$KUBE_DEPLOY_ID \
           --set gitSha=$GITHUB_SHA
-          
+
         echo "##[set-output name=url;]$(echo https://$KUBE_INGRESS_HOSTNAME)"

--- a/.github/actions/deploy/action.yml
+++ b/.github/actions/deploy/action.yml
@@ -118,9 +118,10 @@ runs:
       uses: dopplerhq/cli-action@v2
 
     - name: Show working directory and files
+      shell: bash
       run: |
         pwd
-        ls -l lib/kube/leadgenai-chart/secrets/
+          ls -l lib/kube/leadgenai-chart/secrets/
 
     - name: Apply DopplerSecret manifest
       shell: bash

--- a/.github/actions/deploy/action.yml
+++ b/.github/actions/deploy/action.yml
@@ -114,13 +114,17 @@ runs:
       with:
         version: v3.12.0
 
+    - name: Setup Doppler CLI
+      uses: dopplerhq/cli-action@v2
+      with:
+        doppler-token: ${{ inputs.doppler_token }}
+
     - name: Sync Doppler secrets to Kubernetes
       shell: bash
       env:
         DOPPLER_TOKEN: ${{ inputs.doppler_token }}
       if: "${{ env.DOPPLER_TOKEN != '' }}"
       run: |
-        curl -sLf --retry 3 --retry-delay 2 https://cli.doppler.com/install.sh | sh
         doppler secrets download --format kubernetes --no-file | kubectl apply -f - -n $KUBE_NS
 
     - name: Kubernetes deploy

--- a/.github/actions/deploy/action.yml
+++ b/.github/actions/deploy/action.yml
@@ -122,9 +122,9 @@ runs:
       env:
         DOPPLER_TOKEN: ${{ inputs.doppler_token }}
         KUBE_NS: ${{ env.KUBE_NS }}
-      if: "${{ env.DOPPLER_TOKEN != '' }}"  
+      if: "${{ env.DOPPLER_TOKEN != '' }}"
       run: |
-        doppler secrets download --format kubernetes --no-file | kubectl apply -f - -n $KUBE_NS
+        doppler secrets download --format yaml --no-file | kubectl apply -f - -n $KUBE_NS
 
     - name: Kubernetes deploy
       shell: bash

--- a/.github/actions/deploy/action.yml
+++ b/.github/actions/deploy/action.yml
@@ -117,12 +117,6 @@ runs:
     - name: Setup Doppler CLI
       uses: dopplerhq/cli-action@v2
 
-    - name: Show working directory and files
-      shell: bash
-      run: |
-        pwd
-          ls -l lib/kube/leadgenai-chart/secrets/
-
     - name: Apply DopplerSecret manifest
       shell: bash
       run: kubectl apply -f lib/kube/leadgenai-chart/secrets/doppler-secret.yaml

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "lib/kube/charts-external/leadgenai"]
+	path = lib/kube/charts-external/leadgenai
+	url = https://github.com/jalantechnologies/leadgenai.git


### PR DESCRIPTION
# Feat: Migrate Deployment Workflow to Helm-Based Strategy

## Description
This PR refactors the reusable GitHub Actions workflow to replace the existing shell-based Kubernetes deployment with a Helm-based deployment strategy.  
It also ensures Doppler Operator installation and secrets management are handled dynamically within the workflow.

## Why is this change needed?
- To simplify and standardize Kubernetes deployments using Helm.
- To enable better secret management through Doppler Operator with Helm chart support.
- To prepare for multi-cloud compatibility (AWS, DigitalOcean, GCP, etc.) using a single, unified deployment approach.
- To make deployments more maintainable and extensible for future improvements.

## What does this PR do?

### Common Enhancements
- Introduces Helm-based deployment (`helm upgrade --install`) replacing the previous `deploy.sh` script.
- Adds Doppler Operator installation logic using Helm, ensuring the operator is installed if missing.
- Adds Doppler secrets management using Helm values (`doppler.token`, `doppler.installOperator`).

### Deployment Workflow Changes
- Uses `helm dependency build` to prepare chart dependencies before deployment.
- Uses Helm templating to pass image repository, tag, namespace, deployId, and other runtime variables dynamically.
- Ensures deployments are idempotent by leveraging Helm’s upgrade/install capabilities.
- Improves readability and maintainability of Kubernetes deployment steps.

## Impact
- Fully backward compatible with existing AWS and DigitalOcean pipelines.
- Adds **multi-cloud support**: the workflow now works with any Kubernetes cluster (AWS EKS, DigitalOcean DOKS, GCP GKE, etc.) without changes.
- Simplifies Doppler secret handling and prevents manual Doppler Operator installations.
- Improves reusability for future projects that rely on Kubernetes + Helm.