### PR TITLE
adding the cases dependencies along with build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -258,7 +258,7 @@ jobs:
           docker_password: ${{ secrets.docker_password }}
 
   deploy:
-    needs: build
+    needs: [build, checks]
     runs-on: ubuntu-latest
     outputs:
       url: ${{ steps.deploy.outputs.url }}


### PR DESCRIPTION
**Description**

This PR updates the deployment workflow to enforce stricter dependencies, ensuring deployments only occur after both the build and checks jobs succeed.

**What this PR changes**

Modified the deploy job to depend on both build and checks instead of just build.

**Why this change is needed**

Prevents deployments from running if required checks fail.
