### PR TITLE
chore: update deploy job to depend on build and checks stages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -258,7 +258,7 @@ jobs:
           docker_password: ${{ secrets.docker_password }}
 
   deploy:
-    needs: build
+    needs: [build, checks]
     runs-on: ubuntu-latest
     outputs:
       url: ${{ steps.deploy.outputs.url }}


### PR DESCRIPTION
**Why this changes require**
Previously, the pipeline was configured to run the deploy stage as long as the build stage succeeded. This caused an issue where, even if test cases failed, the deployment stage would still execute. As a result, deployments would fail unnecessarily and consume additional GitHub Actions minutes.

**Change Introduced**

- This update modifies the pipeline so that the deploy stage now depends on both the build and checks stages.
- Deployment will only run if both build and test cases pass.If test cases fail, the deploy stage will be skipped automatically, saving GitHub Actions minutes and avoiding unnecessary failed deployments.


**Manual Test Cases**

**1)PR with failing test cases**

- Raised a PR from the test branch with base branch namra/chore/ci-preview-deploy-conditions.
- Pipeline triggered → build succeeded → test cases failed.
- Result: Deploy stage was skipped, preventing wasted deployment runs.

<img width="1908" height="764" alt="Screenshot 2025-09-08 141507" src="https://github.com/user-attachments/assets/8fb62dcb-6b11-4007-ae6f-d61e0f43e3f4" />


**2)PR with passing the test cases** 
- Raised a PR from the test branch with base branch namra/chore/ci-preview-deploy-conditions.
- Pipeline triggered → build succeeded → test cases passes.
- Result: Deploy stage was executed succesfully as a result pipeline run succesfully .

<img width="1919" height="735" alt="Screenshot 2025-09-08 141533" src="https://github.com/user-attachments/assets/503cc033-c1fe-495c-95a1-9e8f70197e20" />






