### PR TITLE
handle default docker registry tagging in build workflow

### DIFF
--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -85,8 +85,13 @@ runs:
         if [[ "$AWS_USE_ECR" == 'true' ]]; then
           TAG=${{ steps.aws_ecr_login.outputs.registry }}/${{ inputs.app_name }}
         else
-          TAG=${{ inputs.docker_registry }}/${{ inputs.docker_username }}/${{ inputs.app_name }}
+          if [[ -z "${{ inputs.docker_registry }}" || "${{ inputs.docker_registry }}" == "registry.hub.docker.com" ]]; then
+            TAG=${{ inputs.docker_username }}/${{ inputs.app_name }}
+          else
+            TAG=${{ inputs.docker_registry }}/${{ inputs.docker_username }}/${{ inputs.app_name }}
+          fi
         fi
+
 
         echo "value=$(echo $TAG)" >> $GITHUB_OUTPUT
 


### PR DESCRIPTION
Previously, the build workflow always prefixed the Docker image tag with the registry URL, even when using Docker Hub’s default registry.   This caused invalid image references like "registry.hub.docker.com/username/app" during build and push steps.

Added a conditional check to omit the registry prefix when the value is empty or set to Docker Hub’s default.   Now the tagging logic correctly supports:
- AWS ECR (via login output)
- Custom registries
- Default Docker Hub (without redundant prefix)
