### PR TITLE
fix: add image digest in output

### DIFF
--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -44,7 +44,7 @@ outputs:
     value: ${{ steps.tag.outputs.value }}@${{ steps.build.outputs.digest }}
   image_digest: 
     description: 'Built docker image digest'
-    value: ${{ steps.build.ouputs.digest }}
+    value: ${{ steps.build.outputs.digest }}
   image_name:
     description: 'Built docker image name'
     value: ${{ steps.tag.outputs.value }}


### PR DESCRIPTION
## Description
This PR pertains to change in deployment output and will be required in order to match the format that IaC scan requires according  Checkov [CKV_K8S_35](https://www.checkov.io/5.Policy%20Index/kubernetes.html) policy
