### PR TITLE
fix(clean): add --wait=false to prevent kubectl delete from hanging on PVCs

### DIFF
--- a/lib/kube/clean.sh
+++ b/lib/kube/clean.sh
@@ -30,7 +30,7 @@ if [ -d "$kube_shared_dir" ]; then
     for file in "$kube_shared_dir"/*; do
         [ -f "$file" ] || continue
         echo "clean :: deleting → $file"
-        envsubst < "$file" | kubectl delete -n "$KUBE_NS" --ignore-not-found=true -f - || true
+        envsubst < "$file" | kubectl delete -n "$KUBE_NS" --ignore-not-found=true --wait=false -f - || true
     done
 else
     echo "clean :: No shared config found."
@@ -42,7 +42,7 @@ if [ -d "$kube_env_dir" ]; then
     for file in "$kube_env_dir"/*; do
         [ -f "$file" ] || continue
         echo "clean :: deleting → $file"
-        envsubst < "$file" | kubectl delete -n "$KUBE_NS" --ignore-not-found=true -f - || true
+        envsubst < "$file" | kubectl delete -n "$KUBE_NS" --ignore-not-found=true --wait=false -f - || true
     done
 else
     echo "clean :: No environment config found."

--- a/lib/kube/clean.sh
+++ b/lib/kube/clean.sh
@@ -48,6 +48,10 @@ else
     echo "clean :: No environment config found."
 fi
 
+# --- Wait for Resources to be Fully Deleted ---
+echo "clean :: Waiting for resources to be fully deleted..."
+kubectl wait --for=delete pod,deployment,statefulset,pvc -n "$KUBE_NS" -l app="$KUBE_APP" --timeout=300s 2>/dev/null || true
+
 # --- Run Post-Clean Hook ---
 if [ -f "$kube_post_clean_script" ]; then
     echo "clean :: Running post-clean hook → $kube_post_clean_script"


### PR DESCRIPTION
## Summary
Fixes an issue where the clean workflow hangs indefinitely (hitting 6-hour timeout) when deleting preview environments that include PersistentVolumeClaims (PVCs).

## Problem
Currently, the clean workflow:
- Iterates through manifest files alphabetically
- Uses `kubectl delete --wait=true` (default) for each resource
- Hangs when a PVC file is deleted before the Deployment that mounts it
- Causes 6-hour timeouts on every PR close that includes PVCs

This happens because Kubernetes adds a `pvc-protection` finalizer to mounted PVCs. When `kubectl delete` is called on the PVC before the mounting pod is deleted, kubectl blocks waiting for the finalizer to be removed, which never happens because the pod is still running.

**Example from flask-react-template:**
```
clean :: deleting → redis-pvc.yaml
persistentvolumeclaim "...-redis-pvc" deleted   ← marked for deletion, kubectl waits forever
                                                  ← hangs for 6 hours until timeout
```

## Solution
Add `--wait=false` flag to both `kubectl delete` commands in `clean.sh`:
- Script no longer blocks waiting for each resource to be fully deleted
- Kubernetes handles cleanup order via its own garbage collector
- Resources are still deleted properly, just asynchronously

## Changes
Modified `lib/kube/clean.sh`:
- Added `--wait=false` to shared resources deletion loop
- Added `--wait=false` to environment-specific resources deletion loop

## Testing
After merging and releasing:
- Clean workflows complete in seconds instead of timing out
- Preview environments with PVCs are properly cleaned up
- No impact on production resources (clean workflow only affects preview environments)
<img width="1890" height="874" alt="image" src="https://github.com/user-attachments/assets/074072c3-d1c6-4831-9fd5-8a745c05b324" />

## Backward Compatibility
Fully backward compatible - only changes deletion behavior to be non-blocking. All resources are still deleted correctly.

Fixes #112